### PR TITLE
feat: add ElevenLabs TTS support and make image generation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,140 @@
-# Anita - Anki Deck Generator
+# Anita - Smart Anki Deck Generator
 
-A Python tool that automatically generates Anki flashcard decks with audio pronunciation and images. Perfect for language learners who want to create multimedia vocabulary decks.
+![Anita Banner](https://via.placeholder.com/800x200.png?text=Anita+-+AI-Powered+Anki+Deck+Generator)
 
-## Features
+Automatically create rich multimedia Anki decks with AI-generated audio pronunciations and illustrations. Perfect for language learners seeking immersive vocabulary practice.
 
-- **Automated flashcard creation** from CSV vocabulary lists
-- **Text-to-Speech audio** generation for pronunciation using OpenAI's TTS API
-- **AI-generated images** for visual learning using DALL-E 2
-- **Optimized media files** with automatic image resizing
-- **Clean, minimalist card design** focused on effective learning
+## ✨ Features
 
-## Prerequisites
+- 📄 Convert CSV word lists into Anki decks in minutes
+- 🔊 Generate native-like pronunciation audio using OpenAI TTS (or ElevenLabs*)
+- 🖼️ Create memorable illustrations with DALL-E 2
+- 🖌️ Automatic image optimization (resized to 128x128px)
+- 📦 Clean, distraction-free card design
+- 🛠️ Robust error handling and progress tracking
+
+_* ElevenLabs integration optional_
+
+## 📋 Prerequisites
 
 - Python 3.7+
-- OpenAI API key
+- OpenAI API Key (required)
+- ElevenLabs API Key (optional)
 
-## Installation
+## 🚀 Installation
 
-1. Clone the repository:
+1. **Clone repository**
+   ```bash
+   git clone https://github.com/yourusername/anita.git
+   cd anita
+   ```
+
+2. **Install dependencies**
+   ```bash
+   pip install genanki openai requests pillow elevenlabs
+   ```
+
+3. **Set API keys**
+   ```bash
+   # Required OpenAI key
+   export OPENAI_API_KEY='your-openai-key-here'
+   
+   # Optional ElevenLabs key
+   export ELEVENLABS_API_KEY='your-elevenlabs-key-here'
+   ```
+
+## 🛠️ Usage
+
+### Command Line Interface
 ```bash
-git clone https://github.com/yourusername/anita.git
-cd anita
+python -m anita.deck_generator vocabulary.csv output_deck.apkg
 ```
 
-2. Install required dependencies:
-```bash
-pip install genanki openai requests pillow
-```
-
-3. Set your OpenAI API key:
-```bash
-export OPENAI_API_KEY='your-api-key-here'
-```
-
-## Usage
-
-### Basic Usage
-
+### Python API
 ```python
 from anita.deck_generator import AnkiDeckGenerator
 
-# Create generator instance
 generator = AnkiDeckGenerator(
-    deck_name="Italian Vocabulary Deck",
+    deck_name="Italian Essentials",
     deck_id=1234567891
 )
 
-# Generate deck from CSV file
-generator.run("vocabulary.csv", "italian_deck.apkg")
+generator.run("vocabulary.csv", "my_deck.apkg")
 ```
 
-### CSV Format
+### CSV Format Requirements
+Create a CSV with `English,Translation` pairs:
 
-Your input CSV file should have two columns: English and target language (e.g., Italian).
-
-Example `vocabulary.csv`:
-```
+```csv
 apple,mela
 house,casa
 book,libro
 water,acqua
 ```
 
-### Command Line Usage
+## 🔧 Configuration
 
-```bash
-python -m anita.deck_generator vocabulary.csv output_deck.apkg
-```
+Customize the generator with these parameters:
 
-## Configuration
+| Parameter           | Default                      | Description                  |
+|---------------------|------------------------------|------------------------------|
+| `deck_name`         | "Italian Vocabulary Deck"    | Name shown in Anki           |
+| `deck_id`           | 1234567891                   | Unique deck identifier       |
+| `output_media_dir`  | "media"                      | Media storage directory      |
+| `image_size`        | (128, 128)                   | Image dimensions in pixels   |
 
-The `AnkiDeckGenerator` class accepts the following parameters:
+## 🎴 Card Preview
 
-- `deck_name`: Name of your Anki deck (default: "Italian Vocabulary Deck with Images")
-- `deck_id`: Unique identifier for the deck (default: 1234567891)
-- `output_media_dir`: Directory for storing generated media files (default: "media")
+**Front Side**  
+`apple`
 
-## Generated Card Format
+**Back Side**  
+- **Translation**: mela  
+- **Pronunciation**: 🔊 Audio playback  
+- **Visual Aid**: 🖼️ AI-generated apple image
 
-Each flashcard includes:
-- **Front**: English word
-- **Back**: 
-  - Target language translation
-  - Audio pronunciation
-  - AI-generated illustration (128x128px)
+## 🤖 API Integration
 
-## API Usage
+| Service     | Use Case             | Model       | Cost Implications         |
+|-------------|----------------------|-------------|---------------------------|
+| OpenAI      | Text-to-Speech       | TTS-1       | $0.015 per 1k characters  |
+| OpenAI      | Image Generation     | DALL-E 2    | $0.020 per image          |
+| ElevenLabs  | Premium TTS (Optional)| v1         | Depends on subscription   |
 
-The tool uses OpenAI APIs for:
-- **TTS-1** model for audio generation
-- **DALL-E 2** for image generation
+## 📝 Example Workflow
 
-Note: API usage will incur costs based on OpenAI's pricing.
-
-## Error Handling
-
-The generator includes robust error handling:
-- Skips rows with insufficient data
-- Continues processing if individual media generation fails
-- Provides detailed console output for tracking progress
-
-## Example Output
-
-```
+```text
 Processing card 1: apple - mela
-  ✓ Generated audio for 'mela'
-  ✓ Generated image for 'apple'
+  ✓ Generated audio (OpenAI) for 'mela'
+  ✓ Generated image for 'apple' (128x128px)
 Processing card 2: house - casa
-  ✓ Generated audio for 'casa'
-  ✓ Generated image for 'house'
+  ✓ Generated audio (OpenAI) for 'casa'
+  ✓ Generated image for 'house' (128x128px)
 
-✅ Anki Deck Created: italian_deck.apkg
+✅ Deck created: italian_deck.apkg (4 cards)
 ```
 
-## Contributing
+## ⚠️ Important Notes
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+- API costs are incurred for each generation
+- Maintain CSV formatting for error-free processing
+- Store media files locally to avoid regeneration costs
+- First run may take longer due to media generation
 
-## License
+## 🤝 Contributing
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+We welcome contributions! Please see our [Contribution Guidelines](CONTRIBUTING.md) for details.
 
-## Acknowledgments
+## 📄 License
 
-- [genanki](https://github.com/kerrickstaley/genanki) for Anki deck generation
-- [OpenAI](https://openai.com/) for TTS and image generation APIs
+MIT License - See [LICENSE](LICENSE) for full text.
 
+## 🙏 Acknowledgments
 
+- [genanki](https://github.com/kerrickstaley/genanki) for Anki deck creation
+- OpenAI for cutting-edge AI models
+- ElevenLabs for premium voice synthesis options
+
+---
+
+_🔄 Refresh your language learning with AI-powered spaced repetition!_

--- a/create_anki_deck.py
+++ b/create_anki_deck.py
@@ -4,24 +4,31 @@ import os
 
 from anita.deck_generator import AnkiDeckGenerator
 
-# Set your OpenAI API key
-openai.api_key = os.getenv("OPENAI_API_KEY", "your-openai-api-key-here")
 
-# --- Example Usage ---
 if __name__ == "__main__":
-    # Create a dummy input.csv for demonstration
-    with open('input.csv', 'w', newline='', encoding='utf-8') as f:
-        writer = csv.writer(f)
-        writer.writerow(['hello', 'ciao'])
-        writer.writerow(['cat', 'gatto'])
-        writer.writerow(['dog', 'cane'])
-        writer.writerow(['house', 'casa'])
+    # --- Configuration ---
+    INPUT_CSV = os.path.join('resources','restaurant.csv')
+    OUTPUT_DECK_FILE = "Italian_Vocabulary_Deck.apkg"
 
-    deck_generator = AnkiDeckGenerator(deck_name="Italian Vocabulary Restaurant",
-                                        deck_id=1234567890,
-                                        output_media_dir="media"  # This will create a 'media' folder
-)
-    deck_generator.run(input_csv_path=os.path.join('resources','restaurant.csv'),
-                       output_anki_filename='italian_vocab_with_images.apkg')
+    # --- Choose your TTS provider ---
+
+    # -- Option 1: Use OpenAI for TTS (Default) --
+    # generator = AnkiDeckGenerator(tts_provider="openai")
+
+    # -- Option 2: Use ElevenLabs for TTS --
+    # Make sure you have set the ELEVENLABS_API_KEY environment variable.
+    # You can find voice IDs on the ElevenLabs website. "Bella" is a popular choice.
+    generator = AnkiDeckGenerator(
+        tts_provider="elevenlabs",
+        deck_name="Italian Vocabulary with ElevenLabs TTS",
+    )
+
+    # --- Run the generator ---
+    try:
+        generator.generate_deck(INPUT_CSV, OUTPUT_DECK_FILE)
+    except Exception as e:
+        print(f"\n--- FATAL ERROR ---")
+        print(f"The program stopped because of an error: {e}")
+        print("Please check the setup instructions at the top of the script.")
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -199,6 +199,29 @@ files = [
 ]
 
 [[package]]
+name = "elevenlabs"
+version = "2.7.1"
+description = ""
+optional = false
+python-versions = "<4.0,>=3.8"
+groups = ["main"]
+files = [
+    {file = "elevenlabs-2.7.1-py3-none-any.whl", hash = "sha256:076f61f0945c721aa3fa2a63f26029515e8e2464bc64f247b56ae1042a25737a"},
+    {file = "elevenlabs-2.7.1.tar.gz", hash = "sha256:7136cd3e8056fe123ea8736b876aff8023c430aad7fd2c9405cbca60eb675504"},
+]
+
+[package.dependencies]
+httpx = ">=0.21.2"
+pydantic = ">=1.9.2"
+pydantic-core = ">=2.18.2,<3.0.0"
+requests = ">=2.20"
+typing_extensions = ">=4.0.0"
+websockets = ">=11.0"
+
+[package.extras]
+pyaudio = ["pyaudio (>=0.2.14)"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -896,7 +919,86 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[[package]]
+name = "websockets"
+version = "15.0.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c"},
+    {file = "websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256"},
+    {file = "websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf"},
+    {file = "websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85"},
+    {file = "websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597"},
+    {file = "websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9"},
+    {file = "websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4"},
+    {file = "websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa"},
+    {file = "websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880"},
+    {file = "websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411"},
+    {file = "websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123"},
+    {file = "websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f"},
+    {file = "websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee"},
+]
+
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10"
-content-hash = "9ac28682b1777a5e9a099202c22474557f0f8fbcf79490637b8160064ba44253"
+python-versions = ">=3.10,<4.0"
+content-hash = "5b77d42d2fae98cc2af2c33a9f802fafa04f229bfd9af588d96a814dbbf3c68e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,13 @@ authors = [
     {name = "timpara",email = "t.paraskevopoulos@posteo.de"}
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "genanki (>=0.13.1,<0.14.0)",
     "openai (>=1.95.1,<2.0.0)",
     "requests (>=2.32.4,<3.0.0)",
     "pillow (>=11.3.0,<12.0.0)",
+    "elevenlabs (>=2.7.1,<3.0.0)",
 ]
 
 


### PR DESCRIPTION
- Add ElevenLabs as an alternative TTS provider alongside OpenAI
- Make image generation optional with --no-images flag to reduce costs
- Add voice selection support for both TTS providers
- Update configuration to handle provider-specific settings
- Maintain backward compatibility with existing OpenAI implementation

This allows users to choose between OpenAI and ElevenLabs for audio generation and skip expensive DALL-E image generation when not needed.