### PR TITLE
chore: publish as 'anita-anki' on PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/anita
+      url: https://pypi.org/p/anita-anki
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER anita
 WORKDIR /home/anita
 
 COPY --from=build /dist/*.whl /tmp/
-RUN pip install --user --no-cache-dir /tmp/*.whl 'anita[elevenlabs]' \
+RUN pip install --user --no-cache-dir /tmp/*.whl 'anita-anki[elevenlabs]' \
     && rm /tmp/*.whl
 
 ENV PATH="/home/anita/.local/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ into Anki on desktop or mobile.
 
 ```bash
 # Install
-uv tool install anita  # or: pipx install anita
+uv tool install anita-anki  # or: pipx install anita-anki
 
 # Set credentials
 export OPENAI_API_KEY=sk-...
@@ -61,12 +61,15 @@ Import `my_deck.apkg` into Anki and start reviewing.
 ### From PyPI (recommended)
 
 ```bash
-uv tool install anita
+uv tool install anita-anki
 # or
-pipx install anita
+pipx install anita-anki
 # or
-pip install anita
+pip install anita-anki
 ```
+
+> The distribution is published as **`anita-anki`** on PyPI (the name `anita` was taken),
+> but the import name and CLI are both `anita`.
 
 ### From source (development)
 

--- a/anita/providers/tts.py
+++ b/anita/providers/tts.py
@@ -66,7 +66,7 @@ class ElevenLabsTTS:
         except ImportError as exc:
             raise ImportError(
                 "The 'elevenlabs' extra is not installed. "
-                "Install with: pip install 'anita[elevenlabs]'."
+                "Install with: pip install 'anita-anki[elevenlabs]'."
             ) from exc
 
         api_key = os.environ.get("ELEVENLABS_API_KEY")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "anita"
+name = "anita-anki"
 version = "0.1.0"
 description = "AI-powered Anki deck generator: turn a CSV of word pairs into a multimedia .apkg with TTS and illustrations."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
-name = "anita"
+name = "anita-anki"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
The PyPI name 'anita' is already in use by an unrelated project ('Analytic Tableau Proof Assistant'). This PR renames the distribution to 'anita-anki' (the fallback we agreed on). Import name and CLI are unchanged.

- `pyproject.toml`: `name = 'anita-anki'`, builds as `anita_anki-0.1.0-*`
- README: install commands updated; added a note about dist vs import name
- Release workflow environment URL: https://pypi.org/p/anita-anki
- Dockerfile + TTS `ImportError` message reference `anita-anki[elevenlabs]`

Verified locally:
- `uv sync --all-extras` clean
- `uv run ruff check .` / `uv run mypy anita` / `uv run pytest` all pass (23 tests)
- `uv build` produces `anita_anki-0.1.0.tar.gz` and matching wheel