### PR TITLE
feat(release): attach CycloneDX SBOM to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,18 @@ jobs:
         with:
           inputs: requirements-audit.txt
           vulnerability-service: osv
+      - name: Generate SBOM (smoke test)
+        run: |
+          uv export \
+            --frozen \
+            --format cyclonedx1.5 \
+            --all-extras \
+            -o sbom.cdx.json
+          python -c "import json; d = json.load(open('sbom.cdx.json')); \
+            assert d['bomFormat'] == 'CycloneDX', d['bomFormat']; \
+            assert d['specVersion'] == '1.5', d['specVersion']; \
+            assert len(d['components']) > 0, 'no components'; \
+            print(f'OK: {len(d[\"components\"])} components, spec {d[\"specVersion\"]}')"
 
   lint:
     name: Lint & type-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,23 @@ jobs:
         run: uv python install 3.12
       - name: Build sdist + wheel
         run: uv build
-      - name: Upload artifacts
+      - name: Generate CycloneDX SBOM
+        run: |
+          uv export \
+            --frozen \
+            --format cyclonedx1.5 \
+            --all-extras \
+            -o anita-${{ github.ref_name }}-sbom.cdx.json
+      - name: Upload distribution artifacts
         uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: anita-*-sbom.cdx.json
 
   github-release:
     name: Create GitHub release
@@ -33,15 +45,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Download artifacts
+      - name: Download distribution artifacts
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
+      - name: Download SBOM
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom
+          path: sbom/
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/*
+          files: |
+            dist/*
+            sbom/*.cdx.json
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ secrets.yml
 
 # Generated audit artefacts
 requirements-audit.txt
+*.cdx.json
 .coverage.*
 htmlcov/
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ into Anki on desktop or mobile.
 - [Cost estimate](#cost-estimate)
 - [Contributing](#contributing)
 - [License](#license)
+- [Supply chain](#supply-chain)
 
 ## Features
 
@@ -169,6 +170,24 @@ To report a security issue, please see [SECURITY.md](SECURITY.md).
 ## License
 
 [Apache License 2.0](LICENSE) © 2024–present Anita contributors.
+
+## Supply chain
+
+Anita takes a few concrete steps to be a well-behaved dependency:
+
+- **PyPI OIDC trusted publishing** — releases are uploaded from GitHub
+  Actions without any long-lived API token.
+- **Sigstore attestations** — every wheel and sdist on PyPI is signed by
+  `pypa/gh-action-pypi-publish`, so you can verify provenance.
+- **CycloneDX SBOM** — each GitHub Release ships an
+  `anita-v<version>-sbom.cdx.json` bill of materials (CycloneDX 1.5)
+  listing every locked dependency.
+- **Secret scanning** — `gitleaks` runs on every PR, plus GitHub-native
+  push protection.
+- **Dependency auditing** — `pip-audit` scans `uv.lock` on every PR and
+  weekly against OSV.dev.
+
+See [`SECURITY.md`](SECURITY.md) for details and vulnerability reporting.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

Attaches a machine-readable CycloneDX 1.5 SBOM to every GitHub Release for supply-chain transparency. Closes #19.

- **Release workflow**: build job now exports `uv.lock` via `uv export --format cyclonedx1.5 --all-extras` after `uv build`, uploads it as a separate `sbom` artifact. The `github-release` job downloads both `dist` and `sbom` and attaches everything to the Release. `pypi-publish` only downloads `dist`, so the SBOM file can never leak into the PyPI upload.
- **CI smoke test**: new step in the existing `dep-audit` job runs the same export command on every PR and asserts the output is valid CycloneDX 1.5 with at least one component. Catches regressions before a release tag is cut.
- **README**: new "Supply chain" section covering OIDC publishing, Sigstore attestations, SBOMs, secret scanning, and dependency auditing.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | +SBOM generation & upload; +SBOM download in release job; updated `files:` list |
| `.github/workflows/ci.yml` | +SBOM smoke-test step in `dep-audit` |
| `.gitignore` | ignore generated `*.cdx.json` |
| `README.md` | +"Supply chain" section; ToC entry |

## Design notes

**Lockfile-based, not environment-based.** The issue suggested `cyclonedx-py environment`, which introspects the *installed* Python environment. That would include whatever happens to be on the GitHub Actions runner at release time. `uv export --format cyclonedx1.5` works off `uv.lock` — the same source of truth we ship — so the SBOM is deterministic and matches reality.

**Separate artifact for SBOM.** Keeping `dist` (wheel+sdist) and `sbom` as separate upload-artifacts avoids any risk of `pypa/gh-action-pypi-publish` choking on a non-package file. Zero changes to the PyPI publish step.

**Filename convention.** `anita-v<tag>-sbom.cdx.json` — tag-scoped and uses the `.cdx.json` suffix that's standard for CycloneDX (distinguishable from any future SPDX output).

## Test plan

- [x] `uv export --format cyclonedx1.5 --all-extras` generates valid CycloneDX 1.5 locally (60 components, spec 1.5 confirmed)
- [x] `ruff check` / `ruff format` / local tests pass
- [ ] CI `dep-audit` job's new smoke-test step asserts valid JSON shape
- [ ] All 10 required checks stay green
- [ ] End-to-end release path exercises at v0.2.0 tag

## Follow-ups (separate issues)

1. Attest the SBOM via `actions/attest-sbom@v2` (cryptographic binding, same OIDC flow as Sigstore). Not in scope for #19.