### PR TITLE
chore(pre-commit): refresh hooks and add mypy + uv-lock checks

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,50 @@
+name: Pre-commit autoupdate
+
+# Weekly check for new versions of our pre-commit hook repos. If anything
+# bumps, opens a PR for review. Runs every Monday at 06:30 UTC (30 min
+# after the dependency audit), plus on-demand via workflow_dispatch.
+
+on:
+  schedule:
+    - cron: "30 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write # create branch + commit
+  pull-requests: write # open PR
+
+jobs:
+  autoupdate:
+    name: pre-commit autoupdate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Install pre-commit
+        run: uv tool install pre-commit
+      - name: Run autoupdate
+        run: uv tool run pre-commit autoupdate
+      - name: Open PR if anything changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/pre-commit-autoupdate
+          delete-branch: true
+          commit-message: "chore(pre-commit): autoupdate hook versions"
+          title: "chore(pre-commit): autoupdate hook versions"
+          labels: |
+            ci
+            dependencies
+          body: |
+            Automated pre-commit `autoupdate` run.
+
+            This PR bumps one or more hook `rev:` pins in
+            `.pre-commit-config.yaml` to their latest tagged releases.
+
+            Please review each changelog before merging — a minor bump on
+            `ruff-pre-commit`, for example, can introduce new lint rules
+            that break CI.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
         args: ["--maxkb=500"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.11
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -21,3 +21,22 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
+
+  # Project-local hooks run against the uv-managed environment so they
+  # use the exact same toolchain and type stubs as CI.
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy (uv run)
+        entry: uv run mypy anita
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true
+
+      - id: uv-lock-check
+        name: uv lock --check
+        entry: uv lock --check
+        language: system
+        files: ^(pyproject\.toml|uv\.lock)$
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Brings `.pre-commit-config.yaml` up to date with what CI actually enforces, so contributors get the same signal locally as in CI. Closes #35.

## Changes

### Hook version bumps
| Hook | From | To | Notes |
|---|---|---|---|
| `pre-commit-hooks` | v4.6.0 | **v6.0.0** | Major: drops py3.8, removes unused legacy hooks. We target py3.11+ and use neither → zero breakage. |
| `ruff-pre-commit` | v0.6.9 | **v0.15.11** | ~9 minor releases of lint fixes. |
| `gitleaks` | v8.30.1 | v8.30.1 | Already latest (added in #16). |

### New local hooks
Both use `language: system` and `uv run` so they share the project's uv-managed toolchain and pinned type stubs.

- **`mypy (uv run)`** — runs `uv run mypy anita`, matching the CI step exactly. Would have caught the pillow 12 stub incompatibility we had to fix post-push in PR #42.
- **`uv lock --check`** — fires when `pyproject.toml` or `uv.lock` changes; guarantees they stay in sync.

### New workflow
`.github/workflows/pre-commit-autoupdate.yml` runs `pre-commit autoupdate` weekly (Mondays 06:30 UTC, 30 min after the dep-audit run) and opens a PR via `peter-evans/create-pull-request` whenever a hook repo tags a new release. Also supports manual `workflow_dispatch`.

## Test plan

- [x] `pre-commit run --all-files` passes locally on this branch (all 11 hooks)
- [ ] CI green
- [ ] First scheduled autoupdate run can be triggered manually via workflow_dispatch after merge, as a smoke test

## Acceptance-criteria mapping

- [x] All hooks pass on current main (verified locally)
- [x] `autoupdate` runs weekly and opens PRs automatically

## Notes

Autoupdate will only open a PR when there's actually something new to bump — if all three remote hook repos are still at the same version when Monday rolls around, the step is a no-op.