### PR TITLE
fix(cache): regenerate media when files are deleted from disk

### DIFF
--- a/anita/deck.py
+++ b/anita/deck.py
@@ -97,22 +97,23 @@ class AnkiDeckGenerator:
     ) -> tuple[str | None, str | None]:
         cached = self.cache.get(source, target)
         if cached is not None:
-            image_fname, audio_fname = cached
-            log.debug("Cache hit for %s/%s", source, target)
+            cached_image, cached_audio = cached
+            cache_hit = True
         else:
-            safe = _safe_slug(source)
-            audio_fname = f"audio_{safe}_{idx}.mp3"
-            image_fname = f"image_{safe}_{idx}.png" if self.generate_images else None
+            cached_image, cached_audio = None, None
+            cache_hit = False
 
-            audio_path = self.media_dir / audio_fname
-            if not self.tts.synthesize(target, audio_path):
-                audio_fname = None
+        # Reconcile the cache index against the media directory: a filename
+        # that is no longer on disk must be regenerated, even on a cache hit.
+        # Audio and image are reconciled independently so a missing image
+        # doesn't force TTS to re-run (and vice versa).
+        audio_fname = self._reconcile_audio(idx, source, target, cached_audio, cache_hit)
+        image_fname = self._reconcile_image(idx, source, target, cached_image, cache_hit)
 
-            if self.generate_images and image_fname and self.images is not None:
-                image_path = self.media_dir / image_fname
-                if not self.images.generate(source, image_path):
-                    image_fname = None
-
+        # Persist whatever the current truth is (new, regenerated, or
+        # unchanged) so the index matches disk. Always write on a cache miss
+        # so that known-failed generations are remembered.
+        if not cache_hit or (image_fname, audio_fname) != (cached_image, cached_audio):
             self.cache.put(source, target, image_fname, audio_fname)
 
         if audio_fname:
@@ -121,6 +122,78 @@ class AnkiDeckGenerator:
             self.package.media_files.append(str(self.media_dir / image_fname))
 
         return audio_fname, image_fname
+
+    def _reconcile_audio(
+        self,
+        idx: int,
+        source: str,
+        target: str,
+        cached_fname: str | None,
+        cache_hit: bool,
+    ) -> str | None:
+        """Return the audio filename to use, regenerating if the file is gone.
+
+        A recorded ``None`` in the cache means TTS failed on a prior run and
+        is preserved as-is, consistent with the pre-existing behaviour of
+        not retrying known-failed generations.
+        """
+        if cache_hit and cached_fname is None:
+            return None
+        if cached_fname and (self.media_dir / cached_fname).is_file():
+            log.debug("Audio cache hit for %s/%s", source, target)
+            return cached_fname
+
+        if cached_fname:
+            log.info(
+                "Cache listed audio %s for %s/%s but file is missing; regenerating",
+                cached_fname,
+                source,
+                target,
+            )
+
+        safe = _safe_slug(source)
+        audio_fname = cached_fname or f"audio_{safe}_{idx}.mp3"
+        audio_path = self.media_dir / audio_fname
+        if self.tts.synthesize(target, audio_path):
+            return audio_fname
+        return None
+
+    def _reconcile_image(
+        self,
+        idx: int,
+        source: str,
+        target: str,
+        cached_fname: str | None,
+        cache_hit: bool,
+    ) -> str | None:
+        """Return the image filename to use, regenerating if the file is gone.
+
+        A recorded ``None`` in the cache means image generation failed on a
+        prior run and is preserved.
+        """
+        if not self.generate_images or self.images is None:
+            return None
+
+        if cache_hit and cached_fname is None:
+            return None
+        if cached_fname and (self.media_dir / cached_fname).is_file():
+            log.debug("Image cache hit for %s/%s", source, target)
+            return cached_fname
+
+        if cached_fname:
+            log.info(
+                "Cache listed image %s for %s/%s but file is missing; regenerating",
+                cached_fname,
+                source,
+                target,
+            )
+
+        safe = _safe_slug(source)
+        image_fname = cached_fname or f"image_{safe}_{idx}.png"
+        image_path = self.media_dir / image_fname
+        if self.images.generate(source, image_path):
+            return image_fname
+        return None
 
 
 # ---------------------------------------------------------------------- helpers

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -103,3 +103,119 @@ def test_tts_failure_drops_audio_but_keeps_card(tmp_path: Path, sample_csv: Path
     gen.generate_deck(sample_csv, out)
     # Deck still written even with no audio
     assert out.exists()
+
+
+def test_deleted_audio_is_regenerated_on_next_run(tmp_path: Path, sample_csv: Path) -> None:
+    """Cache hit + audio file missing from disk must trigger regeneration (#22)."""
+    tts1 = FakeTTS()
+    gen1 = _make_generator(tmp_path, tts1)
+    gen1.generate_deck(sample_csv, tmp_path / "a.apkg")
+    assert len(tts1.calls) == 3
+
+    # Simulate a user wiping the media directory.
+    media = tmp_path / "media"
+    for f in media.glob("audio_*.mp3"):
+        f.unlink()
+
+    tts2 = FakeTTS()
+    cache = MediaCache(db_path=tmp_path / "cache.db")
+    gen2 = AnkiDeckGenerator(
+        deck_name="Test Deck",
+        tts_provider=tts2,
+        media_dir=media,
+        cache=cache,
+    )
+    out2 = tmp_path / "b.apkg"
+    gen2.generate_deck(sample_csv, out2)
+
+    # All three audio files must have been regenerated and exist on disk.
+    assert len(tts2.calls) == 3
+    assert sorted(p.name for p in media.glob("audio_*.mp3")) == [
+        "audio_apple_0.mp3",
+        "audio_book_2.mp3",
+        "audio_house_1.mp3",
+    ]
+    assert out2.exists()
+
+
+def test_deleted_image_regenerates_only_image_not_audio(tmp_path: Path, sample_csv: Path) -> None:
+    """Missing image must not force TTS to re-run (#22 independence)."""
+    tts1 = FakeTTS()
+    imgs1 = FakeImages()
+    gen1 = _make_generator(tmp_path, tts1, imgs1, generate_images=True)
+    gen1.generate_deck(sample_csv, tmp_path / "a.apkg")
+    assert len(tts1.calls) == 3
+    assert len(imgs1.calls) == 3
+
+    # Delete only the images.
+    media = tmp_path / "media"
+    for f in media.glob("image_*.png"):
+        f.unlink()
+
+    tts2 = FakeTTS()
+    imgs2 = FakeImages()
+    cache = MediaCache(db_path=tmp_path / "cache.db")
+    gen2 = AnkiDeckGenerator(
+        deck_name="Test Deck",
+        tts_provider=tts2,
+        generate_images=True,
+        image_provider=imgs2,
+        media_dir=media,
+        cache=cache,
+    )
+    gen2.generate_deck(sample_csv, tmp_path / "b.apkg")
+
+    # Audio still cached -> TTS not invoked.
+    assert tts2.calls == []
+    # Images regenerated.
+    assert len(imgs2.calls) == 3
+    assert len(list(media.glob("image_*.png"))) == 3
+
+
+def test_deleted_audio_regenerates_only_audio_not_image(tmp_path: Path, sample_csv: Path) -> None:
+    """Missing audio must not force image generation to re-run (#22 independence)."""
+    tts1 = FakeTTS()
+    imgs1 = FakeImages()
+    gen1 = _make_generator(tmp_path, tts1, imgs1, generate_images=True)
+    gen1.generate_deck(sample_csv, tmp_path / "a.apkg")
+
+    media = tmp_path / "media"
+    for f in media.glob("audio_*.mp3"):
+        f.unlink()
+
+    tts2 = FakeTTS()
+    imgs2 = FakeImages()
+    cache = MediaCache(db_path=tmp_path / "cache.db")
+    gen2 = AnkiDeckGenerator(
+        deck_name="Test Deck",
+        tts_provider=tts2,
+        generate_images=True,
+        image_provider=imgs2,
+        media_dir=media,
+        cache=cache,
+    )
+    gen2.generate_deck(sample_csv, tmp_path / "b.apkg")
+
+    assert len(tts2.calls) == 3
+    assert imgs2.calls == []
+    assert len(list(media.glob("audio_*.mp3"))) == 3
+
+
+def test_previous_tts_failure_is_not_retried_on_cache_hit(tmp_path: Path, sample_csv: Path) -> None:
+    """Cache recording ``None`` for audio is preserved, matching prior behaviour."""
+    failing = FakeTTS(should_fail=True)
+    gen1 = _make_generator(tmp_path, failing)
+    gen1.generate_deck(sample_csv, tmp_path / "a.apkg")
+    assert len(failing.calls) == 3  # attempted but all failed
+
+    tts2 = FakeTTS()  # would succeed if called
+    cache = MediaCache(db_path=tmp_path / "cache.db")
+    gen2 = AnkiDeckGenerator(
+        deck_name="Test Deck",
+        tts_provider=tts2,
+        media_dir=tmp_path / "media",
+        cache=cache,
+    )
+    gen2.generate_deck(sample_csv, tmp_path / "b.apkg")
+    # Prior None entries are cache hits; no retry.
+    assert tts2.calls == []


### PR DESCRIPTION
## Summary

Fixes #22. `MediaCache.get()` reports a hit based purely on the SQLite index, so deleting files out of `media/` between runs made the next `anita generate` skip regeneration and later crash inside `genanki.Package.write_to_file()`.

## Changes

`anita/deck.py::_materialize_pair` now reconciles the cache against disk:

- Split into `_reconcile_audio` / `_reconcile_image`. Audio and image are independent — a missing image no longer forces TTS to re-run, and vice versa (per the AC).
- On a cache hit, each cached filename is `is_file()`-checked. Missing files are regenerated and the cache is updated.
- A cached `None` (known-failed generation) is preserved, matching prior behaviour so we don't hammer a flaky provider.
- Always persist on a cache miss, including `(None, None)`, so failures are remembered — previously only the hit branch wrote to the cache for the success path.

## Test plan

`uv run pytest` — 27 passed (4 new):

- `test_deleted_audio_is_regenerated_on_next_run`
- `test_deleted_image_regenerates_only_image_not_audio`
- `test_deleted_audio_regenerates_only_audio_not_image`
- `test_previous_tts_failure_is_not_retried_on_cache_hit`

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy anita` all clean.