### PR TITLE
test(ci): enforce 90% coverage floor and extend CSV/provider tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,9 @@ uv run pytest
 - **Paths:** always `pathlib.Path`, never `os.path`.
 - **Logging:** use the stdlib `logging` module, not `print`.
 - **Tests:** pytest; network calls must be mocked (see the `FakeTTS` /
-  `FakeImages` helpers in `tests/conftest.py`).
+  `FakeImages` helpers in `tests/conftest.py`). CI enforces a **90%
+  coverage floor** (`--cov-fail-under=90`); PRs that drop coverage below
+  that will fail.
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Anita — AI-Powered Anki Deck Generator
 
 [![CI](https://github.com/timpara/anita/actions/workflows/ci.yml/badge.svg)](https://github.com/timpara/anita/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-%E2%89%A590%25-brightgreen)](https://github.com/timpara/anita/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/anita/deck.py
+++ b/anita/deck.py
@@ -203,21 +203,45 @@ def _safe_slug(text: str) -> str:
     return "".join(c for c in text if c.isalnum()) or "item"
 
 
+_HEADER_TOKENS = frozenset(
+    {
+        "source",
+        "target",
+        "word",
+        "translation",
+        "native",
+        "foreign",
+        "english",
+        "front",
+        "back",
+        "term",
+        "definition",
+    }
+)
+
+
+def _looks_like_header(row: list[str]) -> bool:
+    """Return True if every cell in the first row looks like a column label.
+
+    ``csv.Sniffer.has_header`` is unreliable on short 2-column files — it
+    trips on dissimilar rows and strips real data. Instead we opt-in only
+    when every cell (lower-cased, stripped) matches a small allow-list of
+    common header tokens.
+    """
+    if len(row) < 2:
+        return False
+    normalized = [cell.strip().lower() for cell in row[:2]]
+    return all(cell in _HEADER_TOKENS for cell in normalized)
+
+
 def _read_csv(path: Path) -> list[tuple[str, str]]:
     """Read two-column CSV, skipping a header row if detected, dropping bad rows."""
-    with path.open(newline="", encoding="utf-8") as fh:
-        sample = fh.read(2048)
-        fh.seek(0)
-        has_header = False
-        try:
-            has_header = csv.Sniffer().has_header(sample)
-        except csv.Error:
-            has_header = False
-
+    with path.open(newline="", encoding="utf-8-sig") as fh:
         reader = csv.reader(fh)
         rows = list(reader)
 
-    if has_header and rows:
+    has_header = bool(rows) and _looks_like_header(rows[0])
+    if has_header:
         rows = rows[1:]
 
     pairs: list[tuple[str, str]] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ files = ["anita"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers --cov=anita --cov-report=term-missing --cov-fail-under=90"
 testpaths = ["tests"]
 
 [tool.coverage.run]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from anita.cli import app
 from typer.testing import CliRunner
@@ -26,3 +27,47 @@ def test_generate_missing_key_reports_error(tmp_path: Path, monkeypatch, sample_
     result = runner.invoke(app, ["generate", str(sample_csv), str(out)])
     assert result.exit_code == 1
     assert "OPENAI_API_KEY" in (result.stderr or result.stdout)
+
+
+def test_generate_happy_path(tmp_path: Path, sample_csv: Path, mocker: Any) -> None:
+    """The CLI command wires args through to AnkiDeckGenerator and reports success."""
+    fake_generator = mocker.MagicMock()
+    fake_generator.generate_deck.return_value = tmp_path / "deck.apkg"
+    ctor = mocker.patch("anita.cli.AnkiDeckGenerator", return_value=fake_generator)
+
+    out = tmp_path / "deck.apkg"
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            str(sample_csv),
+            str(out),
+            "--deck-name",
+            "My Deck",
+            "--images",
+            "--media-dir",
+            str(tmp_path / "media"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "Deck written" in result.stdout
+    # Constructor received the expected wiring.
+    ctor.assert_called_once()
+    kwargs = ctor.call_args.kwargs
+    assert kwargs["deck_name"] == "My Deck"
+    assert kwargs["tts_provider"] == "openai"
+    assert kwargs["generate_images"] is True
+    assert kwargs["media_dir"] == tmp_path / "media"
+    fake_generator.generate_deck.assert_called_once_with(sample_csv, out)
+
+
+def test_generate_verbose_flag_does_not_break(
+    tmp_path: Path, sample_csv: Path, mocker: Any
+) -> None:
+    fake_generator = mocker.MagicMock()
+    mocker.patch("anita.cli.AnkiDeckGenerator", return_value=fake_generator)
+
+    out = tmp_path / "deck.apkg"
+    result = runner.invoke(app, ["generate", str(sample_csv), str(out), "--verbose"])
+    assert result.exit_code == 0

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -96,6 +96,103 @@ def test_read_csv_skips_malformed_rows(tmp_path: Path) -> None:
     assert _read_csv(csv) == [("apple", "mela"), ("house", "casa")]
 
 
+def test_read_csv_strips_utf8_bom(tmp_path: Path) -> None:
+    """BOM-prefixed content must parse cleanly; the first row must survive."""
+    csv = tmp_path / "bom.csv"
+    csv.write_bytes(b"\xef\xbb\xbfapple,mela\nhouse,casa\n")
+    pairs = _read_csv(csv)
+    # The BOM must be stripped from the first field so downstream slugs are clean.
+    assert pairs == [("apple", "mela"), ("house", "casa")]
+
+
+def test_read_csv_handles_extra_columns(tmp_path: Path) -> None:
+    """Rows wider than 2 columns use the first two and ignore the rest."""
+    csv = tmp_path / "wide.csv"
+    csv.write_text("apple,mela,fruit,red\nhouse,casa,building\n", encoding="utf-8")
+    assert _read_csv(csv) == [("apple", "mela"), ("house", "casa")]
+
+
+def test_read_csv_handles_quoted_cells_with_commas(tmp_path: Path) -> None:
+    """Quoted fields containing commas are one cell."""
+    csv = tmp_path / "quoted.csv"
+    csv.write_text('"good morning","buongiorno, amico"\nhello,ciao\n', encoding="utf-8")
+    assert _read_csv(csv) == [
+        ("good morning", "buongiorno, amico"),
+        ("hello", "ciao"),
+    ]
+
+
+def test_read_csv_trims_whitespace(tmp_path: Path) -> None:
+    csv = tmp_path / "ws.csv"
+    csv.write_text("  apple  ,  mela  \nhouse,casa\n", encoding="utf-8")
+    assert _read_csv(csv) == [("apple", "mela"), ("house", "casa")]
+
+
+def test_read_csv_does_not_misdetect_data_as_header(tmp_path: Path) -> None:
+    """The first row of real data must never be treated as a header."""
+    csv = tmp_path / "data.csv"
+    # Two very dissimilar rows — the old sniffer-based detector would trip here.
+    csv.write_text("apple,mela\n\u4e0a\u6d77,shanghai\n", encoding="utf-8")
+    assert _read_csv(csv) == [("apple", "mela"), ("\u4e0a\u6d77", "shanghai")]
+
+
+def test_read_csv_skips_alternate_header_names(tmp_path: Path) -> None:
+    """Headers beyond 'source,target' — e.g. 'word,translation' — are also detected."""
+    csv = tmp_path / "alt.csv"
+    csv.write_text("word,translation\napple,mela\nhouse,casa\n", encoding="utf-8")
+    assert _read_csv(csv) == [("apple", "mela"), ("house", "casa")]
+
+
+def test_partial_failure_tts_ok_image_fails(
+    tmp_path: Path, sample_csv: Path, fake_tts: FakeTTS
+) -> None:
+    """Image failure must not poison audio on subsequent runs."""
+    failing_images = FakeImages(should_fail=True)
+    gen = _make_generator(tmp_path, fake_tts, failing_images, generate_images=True)
+    gen.generate_deck(sample_csv, tmp_path / "a.apkg")
+
+    # Audio generated, image attempts failed.
+    assert len(fake_tts.calls) == 3
+    assert len(failing_images.calls) == 3
+    assert len(list((tmp_path / "media").glob("audio_*.mp3"))) == 3
+    assert list((tmp_path / "media").glob("image_*.png")) == []
+
+    # Second run: audio must be cached (no TTS call), image still retried
+    # because the cached None is preserved but the overall pipeline still
+    # reports done without regenerating cached assets.
+    tts2 = FakeTTS()
+    imgs2 = FakeImages(should_fail=True)
+    cache = MediaCache(db_path=tmp_path / "cache.db")
+    gen2 = AnkiDeckGenerator(
+        deck_name="Test Deck",
+        tts_provider=tts2,
+        generate_images=True,
+        image_provider=imgs2,
+        media_dir=tmp_path / "media",
+        cache=cache,
+    )
+    gen2.generate_deck(sample_csv, tmp_path / "b.apkg")
+    # Audio is cached on disk → no TTS call.
+    assert tts2.calls == []
+    # Image result was recorded as None → no retry.
+    assert imgs2.calls == []
+
+
+def test_partial_failure_tts_fails_image_ok(
+    tmp_path: Path, sample_csv: Path, fake_images: FakeImages
+) -> None:
+    """TTS failure must not block image generation or card creation."""
+    failing_tts = FakeTTS(should_fail=True)
+    gen = _make_generator(tmp_path, failing_tts, fake_images, generate_images=True)
+    out = tmp_path / "a.apkg"
+    gen.generate_deck(sample_csv, out)
+    assert out.exists()
+    assert len(failing_tts.calls) == 3
+    assert len(fake_images.calls) == 3
+    assert len(list((tmp_path / "media").glob("image_*.png"))) == 3
+    assert list((tmp_path / "media").glob("audio_*.mp3")) == []
+
+
 def test_tts_failure_drops_audio_but_keeps_card(tmp_path: Path, sample_csv: Path) -> None:
     failing_tts = FakeTTS(should_fail=True)
     gen = _make_generator(tmp_path, failing_tts)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import pytest
-from anita.providers.tts import build_tts
+from anita.providers.images import OpenAIImageProvider
+from anita.providers.tts import OpenAITTS, build_tts
 
 
 def test_build_tts_rejects_unknown() -> None:
@@ -21,3 +25,156 @@ def test_build_tts_elevenlabs_requires_key(monkeypatch: pytest.MonkeyPatch) -> N
     # If elevenlabs package isn't installed the error is ImportError; if it is, it's RuntimeError.
     with pytest.raises((RuntimeError, ImportError)):
         build_tts("elevenlabs")
+
+
+# ---- OpenAITTS -------------------------------------------------------------
+
+
+class _FakeSpeechResponse:
+    def __init__(self, payload: bytes = b"ID3fake") -> None:
+        self.payload = payload
+
+    def stream_to_file(self, path: Path) -> None:
+        Path(path).write_bytes(self.payload)
+
+
+def _stub_openai_client(mocker: Any, *, raise_exc: Exception | None = None) -> Any:
+    """Return a mock replacement for openai.OpenAI(...)."""
+    client = mocker.MagicMock()
+    if raise_exc is not None:
+        client.audio.speech.create.side_effect = raise_exc
+    else:
+        client.audio.speech.create.return_value = _FakeSpeechResponse()
+    return client
+
+
+def test_openai_tts_synthesize_writes_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mocker.patch("anita.providers.tts.openai.OpenAI", return_value=_stub_openai_client(mocker))
+
+    provider = OpenAITTS()
+    out = tmp_path / "out.mp3"
+    assert provider.synthesize("hello", out) is True
+    assert out.read_bytes() == b"ID3fake"
+
+
+def test_openai_tts_synthesize_returns_false_on_api_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mocker.patch(
+        "anita.providers.tts.openai.OpenAI",
+        return_value=_stub_openai_client(mocker, raise_exc=RuntimeError("boom")),
+    )
+    provider = OpenAITTS()
+    assert provider.synthesize("hello", tmp_path / "out.mp3") is False
+
+
+def test_build_tts_openai_returns_instance(monkeypatch: pytest.MonkeyPatch, mocker: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mocker.patch("anita.providers.tts.openai.OpenAI", return_value=mocker.MagicMock())
+    tts = build_tts("openai")
+    assert tts.name == "openai"
+
+
+# ---- OpenAIImageProvider ---------------------------------------------------
+
+
+class _FakeImageResponseData:
+    def __init__(self, url: str | None) -> None:
+        self.url = url
+
+
+class _FakeImageResponse:
+    def __init__(self, url: str | None = "https://example/image.png") -> None:
+        self.data = [_FakeImageResponseData(url)] if url is not None else []
+
+
+def _tiny_png_bytes() -> bytes:
+    """A minimal valid PNG that Pillow can open."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (16, 16), (255, 255, 255)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def test_openai_image_provider_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        OpenAIImageProvider()
+
+
+def test_openai_image_provider_generate_happy_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = mocker.MagicMock()
+    client.images.generate.return_value = _FakeImageResponse()
+    mocker.patch("anita.providers.images.openai.OpenAI", return_value=client)
+
+    http_resp = mocker.MagicMock()
+    http_resp.content = _tiny_png_bytes()
+    http_resp.raise_for_status.return_value = None
+    mocker.patch("anita.providers.images.requests.get", return_value=http_resp)
+
+    provider = OpenAIImageProvider()
+    out = tmp_path / "img.png"
+    assert provider.generate("an apple", out) is True
+    assert out.exists()
+    # After _optimize the file is a 128x128 PNG.
+    from PIL import Image
+
+    with Image.open(out) as img:
+        assert img.size == (128, 128)
+
+
+def test_openai_image_provider_returns_false_when_no_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = mocker.MagicMock()
+    client.images.generate.return_value = _FakeImageResponse(url=None)
+    mocker.patch("anita.providers.images.openai.OpenAI", return_value=client)
+
+    provider = OpenAIImageProvider()
+    assert provider.generate("nothing", tmp_path / "nope.png") is False
+
+
+def test_openai_image_provider_returns_false_on_http_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = mocker.MagicMock()
+    client.images.generate.return_value = _FakeImageResponse()
+    mocker.patch("anita.providers.images.openai.OpenAI", return_value=client)
+    mocker.patch(
+        "anita.providers.images.requests.get",
+        side_effect=RuntimeError("connection refused"),
+    )
+
+    provider = OpenAIImageProvider()
+    assert provider.generate("boom", tmp_path / "out.png") is False
+
+
+def test_openai_image_provider_optimize_handles_corrupt_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: Any
+) -> None:
+    """Optimization failure is logged but does not fail the overall call."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = mocker.MagicMock()
+    client.images.generate.return_value = _FakeImageResponse()
+    mocker.patch("anita.providers.images.openai.OpenAI", return_value=client)
+
+    http_resp = mocker.MagicMock()
+    http_resp.content = b"not a real png"
+    http_resp.raise_for_status.return_value = None
+    mocker.patch("anita.providers.images.requests.get", return_value=http_resp)
+
+    provider = OpenAIImageProvider()
+    # generate still returns True — optimization failure only warns.
+    assert provider.generate("prompt", tmp_path / "bad.png") is True


### PR DESCRIPTION
## Summary

Fixes #20. Coverage was uploaded to CI as an artifact but never enforced. Adds `--cov-fail-under=90` to the shared pytest config, lifts baseline coverage from 81% → 94%, and fixes a latent `_read_csv` bug surfaced while writing the new tests.

## Changes

- `pyproject.toml` — pytest `addopts` now carries `--cov=anita --cov-report=term-missing --cov-fail-under=90`, so local and CI runs both enforce the floor.
- New provider tests (`tests/test_providers.py`): mock `openai.OpenAI` and `requests.get` to cover `OpenAITTS.synthesize` (success + error) and `OpenAIImageProvider.generate` (happy path, missing URL, HTTP error, corrupt-file-optimize path). Uses `pytest-mock`, already in dev deps.
- New CLI happy-path test (`tests/test_cli.py`): mocks the generator to verify wiring of `--deck-name`, `--images`, `--media-dir`, TTS provider, CSV/output args; adds a `--verbose` smoke test.
- New deck/CSV tests (`tests/test_deck.py`) per the AC: BOM prefix, extra columns, quoted cells containing commas, whitespace trimming, alternate header names, and a regression guard that the first data row is never misdetected as a header. Plus partial-failure tests (TTS ok + image fails, TTS fails + image ok).
- **Bug fix — `anita/deck.py::_read_csv`**: `csv.Sniffer.has_header` was unreliable on short 2-column files and silently dropped the first data row when the two rows were dissimilar (e.g. `apple,mela\n上海,shanghai`). Replaced with a strict allow-list header detector (`source`, `target`, `word`, `translation`, `native`, `foreign`, `english`, `front`, `back`, `term`, `definition`) and opening the file as `utf-8-sig` so a leading BOM is transparently stripped.
- README: coverage badge.
- CONTRIBUTING: documents the enforced floor.

## Coverage delta

| Module                  | Before | After |
| ----------------------- | -----: | ----: |
| `anita/cli.py`          |    94% |  100% |
| `anita/deck.py`         |    96% |   98% |
| `anita/providers/images.py` |    35% |   98% |
| `anita/providers/tts.py`    |    58% |   74% |
| **Total**               |    81% |   94% |

## Test plan

`uv run pytest` — 45 passed, coverage 93.93% (threshold 90%). `uv run ruff check`, `uv run ruff format --check`, `uv run mypy anita` all clean.