### PR TITLE
feat(cli): add 'anita cache' subcommand group

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,17 @@ every retry.
 
 ### Clearing the cache
 
-There is no `anita cache clear` subcommand yet (tracked separately).
-For now, delete the file directly:
+Anita ships a `cache` subcommand group:
+
+```bash
+anita cache path                          # print the DB path
+anita cache show                          # table of cached (source, target, audio?, image?)
+anita cache show --json                   # machine-readable output
+anita cache clear --yes                   # delete the DB (prompts without --yes)
+anita cache prune --missing-media media/  # drop rows whose media files are gone
+```
+
+If you prefer manual cleanup, remove the file directly:
 
 ```bash
 # Linux

--- a/anita/cache.py
+++ b/anita/cache.py
@@ -81,3 +81,62 @@ class MediaCache:
                 (source, target, image_fname, audio_fname),
             )
             conn.commit()
+
+    def iter_rows(self) -> list[tuple[str, str, str | None, str | None]]:
+        """Return all cached rows as ``(source, target, image_fname, audio_fname)``."""
+        with self._connect() as conn:
+            return [
+                (row[0], row[1], row[2], row[3])
+                for row in conn.execute(
+                    "SELECT source, target, image_fname, audio_fname "
+                    "FROM cards ORDER BY source, target"
+                )
+            ]
+
+    def count(self) -> int:
+        """Return the number of rows currently in the cache index."""
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM cards").fetchone()
+        return int(row[0]) if row else 0
+
+    def clear(self) -> None:
+        """Delete the underlying database file, if it exists."""
+        if self.db_path.exists():
+            self.db_path.unlink()
+
+    def prune_missing(self, media_dir: Path) -> int:
+        """Remove rows whose media files are no longer present on disk.
+
+        A row is pruned when *both* its image and audio filenames either
+        are ``NULL`` or point at files missing from ``media_dir``.
+        Partially-present rows (e.g. audio on disk but image gone) are
+        rewritten to clear only the missing field; this matches the
+        disk-reconciliation semantics used during deck generation.
+
+        Returns the number of rows fully removed.
+        """
+        removed = 0
+        with self._connect() as conn:
+            rows = list(
+                conn.execute(
+                    "SELECT id, image_fname, audio_fname FROM cards",
+                )
+            )
+            for row_id, image_fname, audio_fname in rows:
+                image_ok = bool(image_fname) and (media_dir / image_fname).is_file()
+                audio_ok = bool(audio_fname) and (media_dir / audio_fname).is_file()
+                if not image_ok and not audio_ok:
+                    conn.execute("DELETE FROM cards WHERE id=?", (row_id,))
+                    removed += 1
+                elif image_fname and not image_ok:
+                    conn.execute(
+                        "UPDATE cards SET image_fname=NULL WHERE id=?",
+                        (row_id,),
+                    )
+                elif audio_fname and not audio_ok:
+                    conn.execute(
+                        "UPDATE cards SET audio_fname=NULL WHERE id=?",
+                        (row_id,),
+                    )
+            conn.commit()
+        return removed

--- a/anita/cli.py
+++ b/anita/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ import typer
 from dotenv import load_dotenv
 
 from anita import __version__
+from anita.cache import MediaCache
 from anita.deck import AnkiDeckGenerator
 
 app = typer.Typer(
@@ -19,6 +21,13 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+cache_app = typer.Typer(
+    name="cache",
+    help="Inspect and manage Anita's on-disk media cache.",
+    no_args_is_help=True,
+)
+app.add_typer(cache_app, name="cache")
 
 
 def _version_callback(show: bool) -> None:
@@ -96,6 +105,102 @@ def _configure_logging(verbose: bool) -> None:
         format="%(levelname)s %(name)s: %(message)s",
         stream=sys.stderr,
     )
+
+
+# ------------------------------------------------------------------ cache cmds
+
+
+@cache_app.command("path")
+def cache_path() -> None:
+    """Print the full path to Anita's cache database."""
+    typer.echo(str(MediaCache().db_path))
+
+
+@cache_app.command("show")
+def cache_show(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON instead of a table."),
+    ] = False,
+) -> None:
+    """List cached (source, target, audio?, image?) rows."""
+    cache = MediaCache()
+    rows = cache.iter_rows()
+
+    if as_json:
+        payload = [
+            {
+                "source": s,
+                "target": t,
+                "image_fname": img,
+                "audio_fname": aud,
+            }
+            for s, t, img, aud in rows
+        ]
+        typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
+
+    if not rows:
+        typer.echo("(cache is empty)")
+        return
+
+    # Simple left-aligned columns; no deps on rich/tabulate.
+    src_w = max(6, max(len(s) for s, _, _, _ in rows))
+    tgt_w = max(6, max(len(t) for _, t, _, _ in rows))
+    header = f"{'source':<{src_w}}  {'target':<{tgt_w}}  audio  image"
+    typer.echo(header)
+    typer.echo("-" * len(header))
+    for s, t, img, aud in rows:
+        typer.echo(
+            f"{s:<{src_w}}  {t:<{tgt_w}}  {'yes' if aud else 'no ':<5}  {'yes' if img else 'no'}"
+        )
+    typer.echo(f"\n{len(rows)} row(s)")
+
+
+@cache_app.command("clear")
+def cache_clear(
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+) -> None:
+    """Delete Anita's cache database."""
+    from anita.cache import default_cache_dir
+
+    # Resolve the path without triggering MediaCache's side-effecting init,
+    # so "already empty" reports truthfully on a never-used installation.
+    path = default_cache_dir() / "generated_cards.db"
+    if not path.exists():
+        typer.echo(f"Cache already empty: {path}")
+        return
+    if not yes:
+        confirm = typer.confirm(f"Delete cache database at {path}?", default=False)
+        if not confirm:
+            typer.echo("Aborted.")
+            raise typer.Exit(code=1)
+    path.unlink()
+    typer.echo(f"Removed {path}")
+
+
+@cache_app.command("prune")
+def cache_prune(
+    missing_media: Annotated[
+        Path,
+        typer.Option(
+            "--missing-media",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Media directory to reconcile against.",
+        ),
+    ],
+) -> None:
+    """Remove cache entries whose media files are gone from --missing-media."""
+    cache = MediaCache()
+    removed = cache.prune_missing(missing_media)
+    remaining = cache.count()
+    typer.echo(f"Pruned {removed} row(s); {remaining} remain.")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -29,3 +29,72 @@ def test_db_file_is_created(tmp_path: Path) -> None:
     db = tmp_path / "nested" / "cache.db"
     MediaCache(db_path=db)
     assert db.exists()
+
+
+def test_iter_rows_and_count(cache: MediaCache) -> None:
+    assert cache.iter_rows() == []
+    assert cache.count() == 0
+    cache.put("apple", "mela", "i1.png", "a1.mp3")
+    cache.put("house", "casa", None, "a2.mp3")
+    # Sorted by (source, target).
+    assert cache.iter_rows() == [
+        ("apple", "mela", "i1.png", "a1.mp3"),
+        ("house", "casa", None, "a2.mp3"),
+    ]
+    assert cache.count() == 2
+
+
+def test_clear_removes_db_file(tmp_path: Path, cache: MediaCache) -> None:
+    cache.put("apple", "mela", "i.png", "a.mp3")
+    assert cache.db_path.exists()
+    cache.clear()
+    assert not cache.db_path.exists()
+
+
+def test_clear_is_noop_when_db_missing(tmp_path: Path) -> None:
+    cache = MediaCache(db_path=tmp_path / "c.db")
+    cache.clear()  # creates, removes
+    cache.clear()  # no-op, must not raise
+    assert not cache.db_path.exists()
+
+
+def test_prune_missing_removes_fully_gone_rows(tmp_path: Path, cache: MediaCache) -> None:
+    media = tmp_path / "media"
+    media.mkdir()
+    # Row 1: both files exist.
+    (media / "i1.png").write_bytes(b"x")
+    (media / "a1.mp3").write_bytes(b"x")
+    cache.put("apple", "mela", "i1.png", "a1.mp3")
+    # Row 2: both files gone.
+    cache.put("house", "casa", "i2.png", "a2.mp3")
+
+    removed = cache.prune_missing(media)
+
+    assert removed == 1
+    assert cache.get("apple", "mela") == ("i1.png", "a1.mp3")
+    assert cache.get("house", "casa") is None
+
+
+def test_prune_missing_nulls_partial_rows(tmp_path: Path, cache: MediaCache) -> None:
+    """A row with one file present and one gone must be rewritten, not deleted."""
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "a1.mp3").write_bytes(b"x")  # audio only
+    cache.put("apple", "mela", "gone.png", "a1.mp3")
+
+    removed = cache.prune_missing(media)
+
+    assert removed == 0
+    assert cache.get("apple", "mela") == (None, "a1.mp3")
+
+
+def test_prune_missing_removes_null_only_rows(tmp_path: Path, cache: MediaCache) -> None:
+    """A row that cached (None, None) is always prunable."""
+    media = tmp_path / "media"
+    media.mkdir()
+    cache.put("apple", "mela", None, None)
+
+    removed = cache.prune_missing(media)
+
+    assert removed == 1
+    assert cache.get("apple", "mela") is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
 from anita.cli import app
 from typer.testing import CliRunner
 
@@ -71,3 +72,120 @@ def test_generate_verbose_flag_does_not_break(
     out = tmp_path / "deck.apkg"
     result = runner.invoke(app, ["generate", str(sample_csv), str(out), "--verbose"])
     assert result.exit_code == 0
+
+
+# ------------------------------------------------------------------ cache cmds
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect Anita's default cache dir at a per-test tmp path."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr("anita.cache.default_cache_dir", lambda: cache_dir)
+    return cache_dir
+
+
+def test_cache_path_prints_db_location(isolated_cache: Path) -> None:
+    result = runner.invoke(app, ["cache", "path"])
+    assert result.exit_code == 0
+    assert str(isolated_cache / "generated_cards.db") in result.stdout
+
+
+def test_cache_show_empty(isolated_cache: Path) -> None:
+    result = runner.invoke(app, ["cache", "show"])
+    assert result.exit_code == 0
+    assert "empty" in result.stdout.lower()
+
+
+def test_cache_show_table_lists_rows(isolated_cache: Path) -> None:
+    from anita.cache import MediaCache
+
+    cache = MediaCache()
+    cache.put("apple", "mela", "i.png", "a.mp3")
+    cache.put("house", "casa", None, "b.mp3")
+
+    result = runner.invoke(app, ["cache", "show"])
+    assert result.exit_code == 0
+    assert "apple" in result.stdout
+    assert "house" in result.stdout
+    assert "2 row" in result.stdout
+
+
+def test_cache_show_json_is_parseable(isolated_cache: Path) -> None:
+    import json
+
+    from anita.cache import MediaCache
+
+    cache = MediaCache()
+    cache.put("apple", "mela", "i.png", "a.mp3")
+
+    result = runner.invoke(app, ["cache", "show", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == [
+        {
+            "source": "apple",
+            "target": "mela",
+            "image_fname": "i.png",
+            "audio_fname": "a.mp3",
+        }
+    ]
+
+
+def test_cache_clear_with_yes_flag(isolated_cache: Path) -> None:
+    from anita.cache import MediaCache
+
+    cache = MediaCache()
+    cache.put("apple", "mela", "i.png", "a.mp3")
+    assert cache.db_path.exists()
+
+    result = runner.invoke(app, ["cache", "clear", "--yes"])
+    assert result.exit_code == 0
+    assert "Removed" in result.stdout
+    assert not cache.db_path.exists()
+
+
+def test_cache_clear_already_empty(isolated_cache: Path) -> None:
+    result = runner.invoke(app, ["cache", "clear", "--yes"])
+    assert result.exit_code == 0
+    assert "already empty" in result.stdout.lower()
+
+
+def test_cache_clear_prompt_accepts(isolated_cache: Path) -> None:
+    from anita.cache import MediaCache
+
+    cache = MediaCache()
+    cache.put("apple", "mela", "i.png", "a.mp3")
+
+    result = runner.invoke(app, ["cache", "clear"], input="y\n")
+    assert result.exit_code == 0
+    assert not cache.db_path.exists()
+
+
+def test_cache_clear_prompt_aborts(isolated_cache: Path) -> None:
+    from anita.cache import MediaCache
+
+    cache = MediaCache()
+    cache.put("apple", "mela", "i.png", "a.mp3")
+
+    result = runner.invoke(app, ["cache", "clear"], input="n\n")
+    assert result.exit_code == 1
+    assert cache.db_path.exists()
+
+
+def test_cache_prune_removes_missing(tmp_path: Path, isolated_cache: Path) -> None:
+    from anita.cache import MediaCache
+
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "a1.mp3").write_bytes(b"x")
+
+    cache = MediaCache()
+    cache.put("apple", "mela", None, "a1.mp3")  # audio present
+    cache.put("house", "casa", "gone.png", "gone.mp3")  # both gone
+
+    result = runner.invoke(app, ["cache", "prune", "--missing-media", str(media)])
+    assert result.exit_code == 0
+    assert "Pruned 1" in result.stdout
+    assert "1 remain" in result.stdout


### PR DESCRIPTION
## Summary

Fixes #30. Users could see where the SQLite cache lived (after #32) and knew it self-reconciled against disk (after #22), but had no supported way to inspect or maintain it. Adds the `anita cache` subcommand group.

## Changes

Four subcommands under `anita cache`:

| Command | Purpose |
| --- | --- |
| `anita cache path` | Print the DB path. |
| `anita cache show [--json]` | Tabular or JSON listing of `(source, target, audio?, image?)`. |
| `anita cache clear [--yes]` | Delete the DB; interactive confirm by default. |
| `anita cache prune --missing-media DIR` | Reconcile against a media directory. Rows whose files are all gone are removed; partial hits have the missing field nulled, matching the disk-reconciliation semantics used during deck generation. |

`MediaCache` gains supporting methods: `iter_rows`, `count`, `clear`, `prune_missing`.

README's Cache section is updated to document the group.

## Test plan

`uv run pytest` — 60 passed, coverage 94.71% (threshold 90%). New tests cover:

- All four subcommands (path, show table + JSON, clear `--yes` + interactive accept/abort + already-empty, prune with mixed hits/misses).
- The new `MediaCache` helpers (iter/count/clear/prune) including the partial-pruning path.

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy anita` all clean. `anita --help` and `anita cache --help` render correctly.