### PR TITLE
chore(mypy): enable phase 1 strict flags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,12 @@ strict = false
 warn_unused_ignores = true
 warn_redundant_casts = true
 ignore_missing_imports = true
+# Phase 1 of incremental strictness (issue #23). Phases 2 (per-module
+# ignore_missing_imports) and 3 (strict = true) are tracked in follow-up
+# issues.
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
 files = ["anita"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Closes #23 (phase 1). Turns on three mypy flags in \`pyproject.toml\`:

- \`disallow_untyped_defs = true\`
- \`no_implicit_optional = true\`
- \`warn_return_any = true\`

The codebase was already clean against these — no source changes, no \`# type: ignore\` additions required.

## Follow-ups

- #53 — phase 2: replace global \`ignore_missing_imports = true\` with per-module overrides.
- #54 — phase 3: enable \`strict = true\`.

## Test plan

\`uv run mypy anita\` → \`Success: no issues found in 8 source files\`.
\`uv run pytest\` → 61 passed, 94.71% coverage.
\`uv run ruff check\` + \`uv run ruff format --check\` → clean.